### PR TITLE
Do not use post header as img alt text

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -8,7 +8,7 @@
     <article class="blog-post px-3">
         {% if post.feature_image %}
             <figure>
-                <img class="img-fluid rounded" src="{{ post.feature_image }}" alt="{{ post.title }}"></img>
+                <img class="img-fluid rounded" src="{{ post.feature_image }}" alt=""></img>
             </figure>
         {% endif %}
         <div class="row">


### PR DESCRIPTION
The title of the post isn't a textual alternative for the image, and for screenreaders it would be annoying as it means the title gets read out twice. This header is purely decorative (it doesn't convey any information) so a blank alt attr is appropriate