### PR TITLE
Do not use post title as alt text

### DIFF
--- a/src/_includes/partials/card.njk
+++ b/src/_includes/partials/card.njk
@@ -1,7 +1,7 @@
 {% macro card(post) %}
     <div class="blog-post">
         <figure>
-            <img class="img-fluid rounded-lg" src="{{ post.feature_image }}" alt="{{ post.title }}"></img>
+            <img class="img-fluid rounded-lg" src="{{ post.feature_image }}" alt=""></img>
         </figure>
         <div class="media">
           <img class="author-profile-image rounded-circle d-none d-sm-block" src="{{ post.primary_author.profile_image }}" alt="{{ post.primary_author.name }}"/>


### PR DESCRIPTION
The title of the post isn't a textual alternative for the image, and for screenreaders it would be annoying as it means the title gets read out twice. This header is purely decorative (it doesn't convey any