### PR TITLE
Added alt-text to SVG logo links in header.njk and footer.njk

### DIFF
--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -19,5 +19,5 @@
                         {% if item.label %}
                         <a class="nav-link {% if page.url == item.url %}active{% endif %}" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}">{{ item.label }}</a>
                         {% elif item.svg %}
-                        <a class="nav-link" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}"><svg class="icon" aria-hidden="true" focusable="false"><use xlink:href="#{{ item.svg }}"></use></svg></a>
+                        <a class="nav-link" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}"><svg class="icon" focusable="false" aria-labelledby="title"><title id="title" lang="en">{{ item.svg }} logo link</title><use xlink:href="#{{ item.svg }}"></use></svg></a>
                         {% endif %}

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -15,7 +15,7 @@
                         {% if item.label %}
                         <a class="nav-link {% if page.url == item.url %}active{% endif %}" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}">{{ item.label }}</a>
                         {% elif item.svg %}
-                        <a class="nav-link" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}"><svg class="icon" aria-hidden="true" focusable="false"><use xlink:href="#{{ item.svg }}"></use></svg></a>
+                        <a class="nav-link" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}"><svg class="icon" focusable="false" aria-labelledby="title"><title id="title" lang="en">{{ item.svg }} logo link</title><use xlink:href="#{{ item.svg }}"></use></svg></a>
                         {% endif %}
                     </li>
                     {% endfor %}
@@ -24,4 +24,3 @@
         </nav>
     </header>
 </div>
-


### PR DESCRIPTION
Trello task "Add alt-text to the Facebook and Twitter website links on the website". Added `aria-labelledby` attribute and `<title>` tags to `<svg>` in header and footer for Facebook and Twitter logo links. Removed `aria-hidden=true` attribute (false is the default) to allow content to be presented to screen reader users.