### PR TITLE
Small fixes to ARIA issues and link security

### DIFF
--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,9 +1,9 @@
     <footer class="blog-footer p-4">
         <span>{% for item in site.navigation %}
             {% if item.label %}
-            <a style="color: white;" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}">{{ item.label }}</a>
+            <a style="color: white;" {% if item.newtab == true %}target="_blank" {% endif %} {% if (item.newtab == true) and ('http' in item.url) %}rel="noopener" {% endif %} href="{{ item.url }}">{{ item.label }}</a>
             {% elif item.svg %}
-            <a style="color: white;" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}"><svg class="icon" style="fill: white;" focusable="false" aria-labelledby="title"><title id="title" lang="en">{{ item.svg }} logo link</title><use xlink:href="#{{ item.svg }}"></use></svg></a>
+            <a style="color: white;" {% if item.newtab == true %}target="_blank" {% endif %} {% if (item.newtab == true) and ('http' in item.url) %}rel="noopener" {% endif %} href="{{ item.url }}"><svg class="icon" style="fill: white;" focusable="false" aria-labelledby="{{ item.svg }}_foooter_title"><title id="{{ item.svg }}_foooter_title" lang="en">{{ item.svg }} logo link</title><use xlink:href="#{{ item.svg }}"></use></svg></a>
             {% endif %}
             {% if not loop.last %}&nbsp&nbsp|&nbsp&nbsp{% endif %}
         {% endfor %}</span>

--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -3,7 +3,7 @@
             {% if item.label %}
             <a style="color: white;" {% if item.newtab == true %}target="_blank" {% endif %} {% if (item.newtab == true) and ('http' in item.url) %}rel="noopener" {% endif %} href="{{ item.url }}">{{ item.label }}</a>
             {% elif item.svg %}
-            <a style="color: white;" {% if item.newtab == true %}target="_blank" {% endif %} {% if (item.newtab == true) and ('http' in item.url) %}rel="noopener" {% endif %} href="{{ item.url }}"><svg class="icon" style="fill: white;" focusable="false" aria-labelledby="{{ item.svg }}_foooter_title"><title id="{{ item.svg }}_foooter_title" lang="en">{{ item.svg }} logo link</title><use xlink:href="#{{ item.svg }}"></use></svg></a>
+            <a style="color: white;" {% if item.newtab == true %}target="_blank" {% endif %} {% if (item.newtab == true) and ('http' in item.url) %}rel="noopener" {% endif %} href="{{ item.url }}"><svg class="icon" style="fill: white;" focusable="false" aria-labelledby="{{ item.svg }}_footer_title"><title id="{{ item.svg }}_footer_title" lang="en">{{ item.svg }} logo link</title><use xlink:href="#{{ item.svg }}"></use></svg></a>
             {% endif %}
             {% if not loop.last %}&nbsp&nbsp|&nbsp&nbsp{% endif %}
         {% endfor %}</span>

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -13,9 +13,9 @@
                     {% for item in site.navigation %}
                     <li class="nav-item">
                         {% if item.label %}
-                        <a class="nav-link {% if page.url == item.url %}active{% endif %}" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}">{{ item.label }}</a>
+                        <a class="nav-link {% if page.url == item.url %}active{% endif %}" {% if item.newtab == true %}target="_blank"{% endif %} {% if (item.newtab == true) and ('http' in item.url) %}rel="noopener" {% endif %} href="{{ item.url }}">{{ item.label }}</a>
                         {% elif item.svg %}
-                        <a class="nav-link" {% if item.newtab == true %}target="_blank" {% endif %}href="{{ item.url }}"><svg class="icon" focusable="false" aria-labelledby="title"><title id="title" lang="en">{{ item.svg }} logo link</title><use xlink:href="#{{ item.svg }}"></use></svg></a>
+                        <a class="nav-link" {% if item.newtab == true %}target="_blank" {% endif %} {% if (item.newtab == true) and ('http' in item.url) %}rel="noopener" {% endif %} href="{{ item.url }}"><svg class="icon" focusable="false" aria-labelledby="{{ item.svg }}_header_title"><title id="{{ item.svg }}_header_title" lang="en">{{ item.svg }} logo link</title><use xlink:href="#{{ item.svg }}"></use></svg></a>
                         {% endif %}
                     </li>
                     {% endfor %}

--- a/src/_includes/partials/pagination.njk
+++ b/src/_includes/partials/pagination.njk
@@ -1,5 +1,5 @@
 {% if pagination.previousPageHref or pagination.nextPageHref %}
-    <nav class="pagination btn-group" role="pagination group">
+    <nav class="pagination btn-group" role="navigation" aria-label="Page Navigation">
         {% if page.permalink != pagination.previousPageHref %}
             <a type="button" class="btn btn-primary float-right" href="{{ pagination.previousPageHref }}">Prev page</a>
         {% else %}


### PR DESCRIPTION
1. In footer.njk and header.njk, there existed links to external sites using target="_blank" which did not have a rel="noopener" attribute. This can cause performance issues and can be a security vulnerability. For more information [see here](https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=devtools). This was solved by adding logic to the link template that adds the rel attribute when the _blank attribute is present, and the link has 'http' in it (indicating an external link, as opposed to another page on the site).

2. Once again in footer.njk and header.njk, the svg logo links for Facebook and Twitter received alt text in the last pull request. However, this was not implemented perfectly, as the footer and header links have the same ARIA ID. This can cause screen reader issues, as they can be mistaken to be the same if their IDs are not unique, and could be skipped when being read. For more information [see here](https://web.dev/duplicate-id-aria/?utm_source=lighthouse&utm_medium=devtools). This was fixed by adding footer in the IDs of each link.

3. In pagination.njk, there was an invalid ARIA role. This was assigned as 'pagination group', which is not a valid role. This was changed to 'navigation', the closest valid role, and an aria-label attribute was added to conform to ARIA standards. For more information, [see here](https://web.dev/aria-roles/?utm_source=lighthouse&utm_medium=devtools), [here](https://www.w3.org/TR/wai-aria-1.1/#role_definitions) and [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role).