### PR TITLE
Add a script to check html validity of emails and webpage using W3C validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "build:postprocess_aldes_org_uk_website_css": "postcss .output/websites/aldes_org_uk/css/*.css -u autoprefixer cssnano -r --no-map",
     "build:compile_aldes_org_uk_website_html": "cross-env GHOST_CONTENT_API_KEY=453ce55fdf796124b4a158b334 eleventy --config websites/.aldes_org_uk.eleventy.js",
     "build:postprocess_aldes_org_uk_website_html": "html-minifier --collapse-whitespace --remove-comments --remove-optional-tags --remove-redundant-attributes --remove-script-type-attributes --remove-tag-whitespace --use-short-doctype --minify-css true --minify-js true --input-dir .output/websites/aldes_org_uk/ --output-dir .output/websites/aldes_org_uk/ --file-ext html",
+    "build:validate_html": "node validate.js",
     "deploy": "npm-run-all deploy:*",
     "deploy:sync_justliberals_org_uk_emails": "cd .output/emails; aws s3 sync ./ s3://$JUSTLIBERALS_ORG_UK_EMAIL_BUCKET --delete --acl public-read --size-only --no-progress|cut -d ' ' -f2",
     "deploy:sync_justliberals_org_uk_website": "cd .output/websites/justliberals_org_uk; aws s3 sync ./ s3://$JUSTLIBERALS_ORG_UK_WEBSITE_BUCKET --delete --acl public-read --size-only --no-progress|cut -d ' ' -f2 | tee invalidate",
     "deploy:sync_aldes_org_uk_website": "cd .output/websites/aldes_org_uk; aws s3 sync ./ s3://$ALDES_ORG_UK_WEBSITE_BUCKET --delete --acl public-read --size-only --no-progress|cut -d ' ' -f2 | tee invalidate",
     "deploy:invalidate_justliberals_org_uk_website_changes": "if [ `cat .output/websites/justliberals_org_uk/invalidate` != '' ]; then cat .output/websites/justliberals_org_uk/invalidate|xargs printf -- '/%s\n'|xargs aws cloudfront create-invalidation --distribution-id $JUSTLIBERALS_ORG_UK_DISTRIBUTION --paths; fi",
-    "deploy:invalidate_aldes_org_uk_website_changes": "if [ `cat .output/websites/aldes_org_uk/invalidate` != '' ]; then cat .output/websites/aldes_org_uk/invalidate|xargs printf -- '/%s\n'|xargs aws cloudfront create-invalidation --distribution-id $ALDES_ORG_UK_DISTRIBUTION --paths; fi",
-    "validate": "node validate.js"
+    "deploy:invalidate_aldes_org_uk_website_changes": "if [ `cat .output/websites/aldes_org_uk/invalidate` != '' ]; then cat .output/websites/aldes_org_uk/invalidate|xargs printf -- '/%s\n'|xargs aws cloudfront create-invalidation --distribution-id $ALDES_ORG_UK_DISTRIBUTION --paths; fi"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "deploy:sync_justliberals_org_uk_website": "cd .output/websites/justliberals_org_uk; aws s3 sync ./ s3://$JUSTLIBERALS_ORG_UK_WEBSITE_BUCKET --delete --acl public-read --size-only --no-progress|cut -d ' ' -f2 | tee invalidate",
     "deploy:sync_aldes_org_uk_website": "cd .output/websites/aldes_org_uk; aws s3 sync ./ s3://$ALDES_ORG_UK_WEBSITE_BUCKET --delete --acl public-read --size-only --no-progress|cut -d ' ' -f2 | tee invalidate",
     "deploy:invalidate_justliberals_org_uk_website_changes": "if [ `cat .output/websites/justliberals_org_uk/invalidate` != '' ]; then cat .output/websites/justliberals_org_uk/invalidate|xargs printf -- '/%s\n'|xargs aws cloudfront create-invalidation --distribution-id $JUSTLIBERALS_ORG_UK_DISTRIBUTION --paths; fi",
-    "deploy:invalidate_aldes_org_uk_website_changes": "if [ `cat .output/websites/aldes_org_uk/invalidate` != '' ]; then cat .output/websites/aldes_org_uk/invalidate|xargs printf -- '/%s\n'|xargs aws cloudfront create-invalidation --distribution-id $ALDES_ORG_UK_DISTRIBUTION --paths; fi"
+    "deploy:invalidate_aldes_org_uk_website_changes": "if [ `cat .output/websites/aldes_org_uk/invalidate` != '' ]; then cat .output/websites/aldes_org_uk/invalidate|xargs printf -- '/%s\n'|xargs aws cloudfront create-invalidation --distribution-id $ALDES_ORG_UK_DISTRIBUTION --paths; fi",
+    "validate": "node validate.js"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.12.1",
@@ -46,7 +47,8 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.2.14",
     "postcss-cli": "^8.3.1",
-    "sass": "^1.32.12"
+    "sass": "^1.32.12",
+    "node": "^10.19.0"
   },
   "browserslist": [
     "last 2 versions"

--- a/validate.js
+++ b/validate.js
@@ -4,27 +4,73 @@ var path = require("path");
 var http = require("http");
 
 ignored_email_errors = [
-  "Element “title” must not be empty."
+  "Attribute “xmlns:v” not allowed here.",
+  "Attribute “xmlns:o” not allowed here.",
+  "Element “title” must not be empty.",
+  "CSS: “mso-table-lspace”: Property “mso-table-lspace” doesn't exist.",
+  "CSS: “mso-table-rspace”: Property “mso-table-rspace” doesn't exist.",
+  "CSS: “text-decoration-thickness”: Property “text-decoration-thickness” doesn't exist.",
+  "The “align” attribute on the “table” element is obsolete. Use CSS instead.",
+  "The “cellpadding” attribute on the “table” element is obsolete. Use CSS instead.",
+  "The “cellspacing” attribute on the “table” element is obsolete. Use CSS instead.",
+  "The “border” attribute on the “table” element is obsolete. Use CSS instead.",
+  "The “width” attribute on the “table” element is obsolete. Use CSS instead.",
+  "The “align” attribute on the “td” element is obsolete. Use CSS instead.",
+  "CSS: The value “break-word” is deprecated",
+  "Attribute “vertical-align” not allowed on element “td” at this point.",
+  "The “bgcolor” attribute on the “td” element is obsolete. Use CSS instead.",
+  "CSS: “mso-padding-alt”: Property “mso-padding-alt” doesn't exist.",
+  "The “valign” attribute on the “td” element is obsolete. Use CSS instead.",
+  "Bad value “mailto:hello@justliberals.org.uk?subject=Weekly Briefing” for attribute “href” on element “a”: Illegal character in query: space is not allowed.",
+  "Attribute “width” not allowed on element “div” at this point.",
+  // Caused by templates not actually being HTML
+  "Bad value “{{ validation_path }}” for attribute “href” on element “a”: Illegal character in path segment: “{” is not allowed.",
+  "Bad value “{{ unsubscribe_path }}” for attribute “href” on element “a”: Illegal character in path segment: “{” is not allowed.",
+  "Non-space character in page trailer.",
 ];
 
-ignored_errors = [
-  "No space between attributes."
+ignored_website_errors = [
+  "Missing space before doctype name.",
+  "No space between attributes.",
+  "Duplicate ID “facebook”.",
+  "Duplicate ID “twitter”.",
+  "Duplicate ID “link”.",
+  "Bad value “100%” for attribute “width” on element “img”: Expected a digit but saw “%” instead.",
+  "Attribute “preserveaspectratio” not allowed on element “img” at this point.",
+  "Attribute “focusable” not allowed on element “img” at this point.",
+  "An “img” element which has an “alt” attribute whose value is the empty string must not have a “role” attribute with any value other than “none” or “presentation”",
+  "An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.",
+  "The “itemprop” attribute was specified, but the element is not a property of any item.",
+  "Bad value “button” for attribute “type” on element “a”: Subtype missing.",
+  "Discarding unrecognized token “pagination” from value of attribute “role”. Browsers ignore any token that is not a defined ARIA non-abstract role.",
+  "Bad value “group” for attribute “role” on element “nav”.",
+  "Bad value “” for attribute “href” on element “link”: Must be non-empty.",
+  "Named character reference was not terminated by a semicolon. (Or “&” should have been escaped as “&amp;”.)",
+  "The “align” attribute on the “div” element is obsolete. Use CSS instead.",
+  "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.",
+  "Attribute “lang” not allowed on element “title” at this point.",
+  "The “for” attribute of the “label” element must refer to a non-hidden form control.",
+  "Bad value  for attribute “d” on element “path”."
 ];
+
+total_errors = 0;
 
 function handleReport(path, report, isEmail) {
-  errors = []
+  errors = [];
   report.messages.forEach(function (item) {
-    if (!["info", "warning"].includes(item.type) && !ignored_errors.includes(item.message)) {
-      if (!ignored_email_errors.includes(item.message) || !isEmail) {
+    if (!["info", "warning"].includes(item.type)) {
+      if ((!ignored_email_errors.includes(item.message) || !isEmail) &&
+          (!ignored_website_errors.includes(item.message) || isEmail)) {
         errors.push(item);
       };
     }
   });
-  if (errors != []) {
+  if (errors.length != 0) {
     console.log(path, ": ", errors.length, " errors");
+    total_errors += errors.length;
     process.exitCode = 1;
-  }
-  fs.writeFile(path + ".json", JSON.stringify(errors, null, 2), function (){});
+    fs.writeFile(path + ".json", JSON.stringify(errors, null, 2), function (){});
+  };
 }
 
 // Based on gist.github.com/lovasoa/8691344
@@ -47,8 +93,8 @@ async function* filesToScan() {
 (async function () {
   for await (const [filepath, isEmail] of filesToScan()) {
     const options = {
-      hostname: "validator.w3.org",
-      path: "/nu/?out=json",
+      hostname: "validator.nu",
+      path: "/?out=json",
       method: "POST",
       headers: {
         "User-Agent" : "Mozilla/5.0",
@@ -56,15 +102,16 @@ async function* filesToScan() {
       }
     };
     const req = http.request(options, function (res) {
-      assert(res.statusCode == 200);
+      assert.strictEqual(res.statusCode, 200);
 
-      var str = "";
+      var buffers = [];
 
       res.on("data", function(chunk){
-        str += chunk;
+        buffers.push(chunk);
       });
 
       res.on("end", function(){
+        str = Buffer.concat(buffers).toString();
         handleReport(filepath, JSON.parse(str), isEmail);
       });
 
@@ -72,4 +119,12 @@ async function* filesToScan() {
 
     fs.createReadStream(filepath).pipe(req);
   };
+
+  process.on('exit', function () {
+    if (total_errors != 0) {
+      console.log('Total errors: ', total_errors);
+    } else {
+      console.log("Validation successful!")
+    }
+  });
 })()

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,75 @@
+var assert = require("assert");
+var fs = require("fs");
+var path = require("path");
+var http = require("http");
+
+ignored_email_errors = [
+  "Element “title” must not be empty."
+];
+
+ignored_errors = [
+  "No space between attributes."
+];
+
+function handleReport(path, report, isEmail) {
+  errors = []
+  report.messages.forEach(function (item) {
+    if (!["info", "warning"].includes(item.type) && !ignored_errors.includes(item.message)) {
+      if (!ignored_email_errors.includes(item.message) || !isEmail) {
+        errors.push(item);
+      };
+    }
+  });
+  if (errors != []) {
+    console.log(path, ": ", errors.length, " errors");
+    process.exitCode = 1;
+  }
+  fs.writeFile(path + ".json", JSON.stringify(errors, null, 2), function (){});
+}
+
+// Based on gist.github.com/lovasoa/8691344
+async function* walk(dir) {
+    for (const d of fs.readdirSync(dir)) {
+        const entry = path.join(dir, d);
+        const stats = fs.statSync(entry);
+        if (stats.isDirectory()) yield* walk(entry);
+        else if (stats.isFile()) yield entry;
+    }
+}
+
+async function* filesToScan() {
+  for await (const filename of walk(".output")) {
+    if (filename.endsWith(".j2")) yield [filename, true]
+    else if (filename.endsWith(".html")) yield [filename, false];
+  }
+}
+
+(async function () {
+  for await (const [filepath, isEmail] of filesToScan()) {
+    const options = {
+      hostname: "validator.w3.org",
+      path: "/nu/?out=json",
+      method: "POST",
+      headers: {
+        "User-Agent" : "Mozilla/5.0",
+        "Content-Type" : "text/html; charset=utf-8"
+      }
+    };
+    const req = http.request(options, function (res) {
+      assert(res.statusCode == 200);
+
+      var str = "";
+
+      res.on("data", function(chunk){
+        str += chunk;
+      });
+
+      res.on("end", function(){
+        handleReport(filepath, JSON.parse(str), isEmail);
+      });
+
+    });
+
+    fs.createReadStream(filepath).pipe(req);
+  };
+})()


### PR DESCRIPTION
This pull request adds a `validate.js` script that checks the validity of using the validator at `validator.w3.org`. For each file with errors it places a json summary of the errors in `filename + ".json"`. If any file has errors the script exits with failure. You can ignore specific errors by adding them to `ignored_errors` and `ignored_email_errors` at the top of `validate.js`.

Currently the repository contains large numbers of unignored errors in every file.